### PR TITLE
Endre tittel på søknad og ettersendelse

### DIFF
--- a/src/main/kotlin/no/nav/aap/api/felles/Søker.kt
+++ b/src/main/kotlin/no/nav/aap/api/felles/Søker.kt
@@ -50,7 +50,7 @@ data class Adresse (val adressenavn: String?, val husbokstav: String?, val husnu
 enum class SkjemaType(val kode: String, val tittel: String) {
     UTLAND_SØKNAD("NAV 11-03.07", "Søknad om å beholde AAP ved opphold i utlandet"),
     UTLAND_ETTERSENDING("NAVe 11-03.07", "Ettersending til ${UTLAND_SØKNAD.tittel.decap()}"),
-    STANDARD("NAV 11-13.05", "Søknad om AAP"),
-    STANDARD_ETTERSENDING("NAVe 11-13.05", "Ettersending AAP")
+    STANDARD("NAV 11-13.05", "Søknad om arbeidsavklaringspenger"),
+    STANDARD_ETTERSENDING("NAVe 11-13.05", "Ettersendelse til søknad om arbeidsavklaringspenger")
 
 }


### PR DESCRIPTION
Vi ble forespurt om å endre titlene vi setter slik at det blir like titler med det som sendes inn via scanning og tidligere digital søknad. "Hei igjen!
Supert om dere kan si fra når dette er gjort. Og bruk gjerne ordlyden Søknad om arbeidsavklaringspenger når vi først er i gang. (altså med liten a).
Vh Liz"